### PR TITLE
feat(filter-store): remove empty filter keys on apply

### DIFF
--- a/src/store/useFilterStore.ts
+++ b/src/store/useFilterStore.ts
@@ -42,7 +42,11 @@ export const useFilterStore = create(
 				set({ isSubmitting: true })
 				setTimeout(() => {
 					set(state => ({
-						filters: { ...state.tempFilters },
+						filters: Object.fromEntries(
+							Object.entries(state.tempFilters).filter(
+								([, arr]) => arr.length > 0
+							)
+						),
 						isSubmitting: false
 					}))
 					if (onSuccess) {


### PR DESCRIPTION
Now when applying filters, all keys with empty arrays are automatically removed from persisted storage. This prevents saving empty filters and keeps the state clean.